### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/dbartilson/fh_table/security/code-scanning/1](https://github.com/dbartilson/fh_table/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs in this file. For this build/test workflow, `contents: read` is the minimal appropriate permission and preserves existing behavior (checkout + build/test).  
Edit `.github/workflows/cmake-build-test.yml` near the top-level keys, immediately after `on:` (or before `jobs:`), adding:

```yml
permissions:
  contents: read
```

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
